### PR TITLE
Add support for basic contract tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1663,6 +1663,7 @@ dependencies = [
  "blockifier",
  "cairo-annotations",
  "cairo-lang-casm",
+ "cairo-lang-sierra",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
  "cairo-native",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,7 @@ dependencies = [
  "cairo-lang-casm",
  "cairo-lang-starknet-classes",
  "cairo-lang-utils",
+ "cairo-native",
  "cairo-vm",
  "camino",
  "conversions",

--- a/crates/cheatnet/Cargo.toml
+++ b/crates/cheatnet/Cargo.toml
@@ -17,6 +17,7 @@ cairo-lang-casm.workspace = true
 cairo-lang-utils.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-vm.workspace = true
+cairo-native.workspace = true
 cairo-annotations.workspace = true
 regex.workspace = true
 indoc.workspace = true

--- a/crates/cheatnet/Cargo.toml
+++ b/crates/cheatnet/Cargo.toml
@@ -14,6 +14,7 @@ camino.workspace = true
 starknet_api.workspace = true
 starknet-types-core.workspace = true
 cairo-lang-casm.workspace = true
+cairo-lang-sierra.workspace = true
 cairo-lang-utils.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-vm.workspace = true

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/entry_point.rs
@@ -1,4 +1,5 @@
 use super::cairo1_execution::execute_entry_point_call_cairo1;
+use super::native_execution::execute_entry_point_call_native;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::execution::deprecated::cairo0_execution::execute_entry_point_call_cairo0;
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{AddressOrClassHash, CallResult};
 use crate::runtime_extensions::call_to_blockifier_runtime_extension::CheatnetState;
@@ -172,8 +173,14 @@ pub fn execute_call_entry_point(
             cheatnet_state,
             context,
         ),
-        RunnableCompiledClass::V1Native(_) => {
-            todo!("execute inner call with Cairo Native")
+        RunnableCompiledClass::V1Native(native_compiled_class_v1) => {
+            execute_entry_point_call_native(
+                entry_point.clone(),
+                &native_compiled_class_v1,
+                state,
+                cheatnet_state,
+                context,
+            )
         }
     };
     context

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/mod.rs
@@ -4,4 +4,5 @@ pub mod cheated_syscalls;
 pub mod deprecated;
 pub mod entry_point;
 pub mod execution_info;
+pub mod native_execution;
 pub mod syscall_hooks;

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/native_execution.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/execution/native_execution.rs
@@ -1,0 +1,139 @@
+use std::collections::HashMap;
+
+use blockifier::{
+    execution::{
+        call_info::{CallExecution, CallInfo, Retdata},
+        contract_class::TrackedResource,
+        entry_point::{EntryPointExecutionContext, ExecutableCallEntryPoint},
+        errors::{EntryPointExecutionError, PostExecutionError, PreExecutionError},
+        native::{contract_class::NativeCompiledClassV1, syscall_handler::NativeSyscallHandler},
+        syscalls::vm_syscall_utils::SyscallUsageMap,
+    },
+    state::state_api::State,
+};
+use cairo_native::{execution_result::ContractExecutionResult, utils::BuiltinCosts};
+use runtime::native::{NativeExtendedRuntime, NativeStarknetRuntime};
+
+use crate::{
+    runtime_extensions::cheatable_starknet_runtime_extension::CheatableStarknetRuntimeExtension,
+    state::CheatnetState,
+};
+
+use super::entry_point::{CallInfoWithExecutionData, ContractClassEntryPointExecutionResult};
+
+// blockifier/src/execution/native/entry_point_execution.rs:20 (execute_entry_point_call)
+#[expect(clippy::result_large_err)]
+pub(crate) fn execute_entry_point_call_native(
+    call: ExecutableCallEntryPoint,
+    compiled_class: &NativeCompiledClassV1,
+    state: &mut dyn State,
+    cheatnet_state: &mut CheatnetState, // Added parameter
+    context: &mut EntryPointExecutionContext,
+) -> ContractClassEntryPointExecutionResult {
+    let entry_point = compiled_class.get_entry_point(&call.type_and_selector())?;
+
+    let syscall_handler: NativeSyscallHandler<'_> = NativeSyscallHandler::new(call, state, context);
+
+    let gas_costs = syscall_handler.base.context.gas_costs();
+    let builtin_costs = BuiltinCosts {
+        r#const: 1,
+        pedersen: gas_costs.builtins.pedersen,
+        bitwise: gas_costs.builtins.bitwise,
+        ecop: gas_costs.builtins.ecop,
+        poseidon: gas_costs.builtins.poseidon,
+        add_mod: gas_costs.builtins.add_mod,
+        mul_mod: gas_costs.builtins.mul_mod,
+    };
+
+    let initial_budget = syscall_handler
+        .base
+        .context
+        .gas_costs()
+        .base
+        .entry_point_initial_budget;
+    let call_initial_gas = syscall_handler
+        .base
+        .call
+        .initial_gas
+        .checked_sub(initial_budget)
+        .ok_or(PreExecutionError::InsufficientEntryPointGas)?;
+
+    // region: Modified blockifier code
+    let mut cheatable_runtime = NativeExtendedRuntime {
+        extension: CheatableStarknetRuntimeExtension { cheatnet_state },
+        runtime: NativeStarknetRuntime { syscall_handler },
+    };
+    let execution_result = compiled_class.executor.run(
+        entry_point.selector.0,
+        &cheatable_runtime
+            .runtime
+            .syscall_handler
+            .base
+            .call
+            .calldata
+            .0
+            .clone(),
+        call_initial_gas,
+        Some(builtin_costs),
+        &mut cheatable_runtime,
+    );
+    let mut syscall_handler = cheatable_runtime.runtime.syscall_handler;
+    // endregion
+
+    syscall_handler.finalize();
+
+    let call_result = execution_result.map_err(EntryPointExecutionError::NativeUnexpectedError)?;
+
+    if let Some(error) = syscall_handler.unrecoverable_error {
+        return Err(EntryPointExecutionError::NativeUnrecoverableError(Box::new(error)).into());
+    }
+
+    let call_info_result = create_callinfo(call_result, syscall_handler);
+
+    // region: Modified blockifier code
+    Ok(CallInfoWithExecutionData {
+        call_info: call_info_result?,
+        syscall_usage_vm_resources: SyscallUsageMap::default(),
+        syscall_usage_sierra_gas: SyscallUsageMap::default(),
+        vm_trace: None,
+    })
+    // endregion
+}
+
+#[allow(clippy::result_large_err)]
+fn create_callinfo(
+    call_result: ContractExecutionResult,
+    syscall_handler: NativeSyscallHandler<'_>,
+) -> Result<CallInfo, EntryPointExecutionError> {
+    let remaining_gas = call_result.remaining_gas;
+
+    if remaining_gas > syscall_handler.base.call.initial_gas {
+        return Err(PostExecutionError::MalformedReturnData {
+            error_message: format!(
+                "Unexpected remaining gas. Used gas is greater than initial gas: {} > {}",
+                remaining_gas, syscall_handler.base.call.initial_gas
+            ),
+        }
+        .into());
+    }
+
+    let gas_consumed = syscall_handler.base.call.initial_gas - remaining_gas;
+    let vm_resources = CallInfo::summarize_vm_resources(syscall_handler.base.inner_calls.iter());
+
+    Ok(CallInfo {
+        call: syscall_handler.base.call.into(),
+        execution: CallExecution {
+            retdata: Retdata(call_result.return_values),
+            events: syscall_handler.base.events,
+            cairo_native: true,
+            l2_to_l1_messages: syscall_handler.base.l2_to_l1_messages,
+            failed: call_result.failure_flag,
+            gas_consumed,
+        },
+        resources: vm_resources,
+        inner_calls: syscall_handler.base.inner_calls,
+        storage_access_tracker: syscall_handler.base.storage_access_tracker,
+        tracked_resource: TrackedResource::SierraGas,
+        builtin_counters: HashMap::default(),
+    })
+}

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
@@ -96,7 +96,7 @@ impl<'a> NativeExtensionLogic for CallToBlockifierExtension<'a> {
         address: cairo_vm::Felt252,
         entry_point_selector: cairo_vm::Felt252,
         calldata: &[cairo_vm::Felt252],
-        remaining_gas: &mut u64,
+        _remaining_gas: &mut u64,
         runtime: &mut Self::Runtime,
     ) -> NativeSyscallHandlingResult<SyscallResult<Vec<cairo_vm::Felt252>>> {
         let contract_address = ContractAddress::try_from(address).unwrap();

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/mod.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use std::sync::Arc;
 
 use blockifier::execution::entry_point::{CallEntryPoint, CallType};
 use blockifier::execution::execution_utils::felt_from_ptr;
@@ -11,12 +12,15 @@ use blockifier::execution::{
     execution_utils::ReadOnlySegment,
     syscalls::vm_syscall_utils::{SyscallRequest, SyscallResponse, SyscallResponseWrapper},
 };
+use cairo_native::starknet::SyscallResult;
 use cairo_vm::types::relocatable::MaybeRelocatable;
 use cairo_vm::vm::{errors::hint_errors::HintError, vm_core::VirtualMachine};
-use runtime::native::{NativeExtendedRuntime, NativeExtensionLogic};
+use conversions::serde::serialize::SerializeToFeltVec;
+use runtime::native::{NativeExtendedRuntime, NativeExtensionLogic, NativeSyscallHandlingResult};
 use runtime::{ExtendedRuntime, ExtensionLogic, SyscallHandlingResult, SyscallPtrAccess};
 use starknet_api::contract_class::EntryPointType;
-use starknet_api::core::ContractAddress;
+use starknet_api::core::{ContractAddress, EntryPointSelector};
+use starknet_api::transaction::fields::Calldata;
 
 use crate::state::CheatnetState;
 
@@ -86,6 +90,46 @@ impl<'a> ExtensionLogic for CallToBlockifierExtension<'a> {
 
 impl<'a> NativeExtensionLogic for CallToBlockifierExtension<'a> {
     type Runtime = &'a mut NativeExtendedRuntime<CheatableStarknetRuntimeExtension<'a>>;
+
+    fn handle_call_contract(
+        &mut self,
+        address: cairo_vm::Felt252,
+        entry_point_selector: cairo_vm::Felt252,
+        calldata: &[cairo_vm::Felt252],
+        remaining_gas: &mut u64,
+        runtime: &mut Self::Runtime,
+    ) -> NativeSyscallHandlingResult<SyscallResult<Vec<cairo_vm::Felt252>>> {
+        let contract_address = ContractAddress::try_from(address).unwrap();
+
+        let entry_point = CallEntryPoint {
+            class_hash: None,
+            code_address: Some(contract_address),
+            entry_point_type: EntryPointType::External,
+            entry_point_selector: EntryPointSelector(entry_point_selector),
+            calldata: Calldata(Arc::new(calldata.to_vec())),
+            storage_address: contract_address,
+            caller_address: TryFromHexStr::try_from_hex_str(TEST_ADDRESS).unwrap(),
+            call_type: CallType::Call,
+            initial_gas: i64::MAX as u64,
+        };
+
+        let result = call_entry_point(
+            &mut runtime.runtime.syscall_handler.base,
+            runtime.extension.cheatnet_state,
+            entry_point,
+            &AddressOrClassHash::ContractAddress(contract_address),
+        );
+
+        match result {
+            CallResult::Success { ret_data } => NativeSyscallHandlingResult::Handled(Ok(ret_data)),
+            CallResult::Failure(call_failure) => {
+                NativeSyscallHandlingResult::Handled(Err(match call_failure {
+                    CallFailure::Panic { panic_data } => panic_data,
+                    CallFailure::Error { msg } => msg.serialize_to_vec(),
+                }))
+            }
+        }
+    }
 }
 
 trait ExecuteCall
@@ -120,7 +164,7 @@ impl ExecuteCall for CallContractRequest {
         };
 
         call_entry_point(
-            syscall_handler,
+            &mut syscall_handler.base,
             cheatnet_state,
             entry_point,
             &AddressOrClassHash::ContractAddress(contract_address),
@@ -149,7 +193,7 @@ impl ExecuteCall for LibraryCallRequest {
         };
 
         call_entry_point(
-            syscall_handler,
+            &mut syscall_handler.base,
             cheatnet_state,
             entry_point,
             &AddressOrClassHash::ClassHash(class_hash),

--- a/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
+++ b/crates/cheatnet/src/runtime_extensions/call_to_blockifier_runtime_extension/rpc.rs
@@ -9,7 +9,7 @@ use blockifier::execution::{
     call_info::CallInfo,
     entry_point::{CallType, EntryPointExecutionResult},
     errors::{EntryPointExecutionError, PreExecutionError},
-    syscalls::hint_processor::SyscallHintProcessor,
+    syscalls::{hint_processor::SyscallHintProcessor, syscall_base::SyscallHandlerBase},
 };
 use blockifier::execution::{
     entry_point::CallEntryPoint, syscalls::vm_syscall_utils::SyscallUsageMap,
@@ -192,7 +192,7 @@ pub fn call_l1_handler(
     };
 
     call_entry_point(
-        syscall_handler,
+        &mut syscall_handler.base,
         cheatnet_state,
         entry_point,
         &AddressOrClassHash::ContractAddress(*contract_address),
@@ -200,23 +200,23 @@ pub fn call_l1_handler(
 }
 
 pub fn call_entry_point(
-    syscall_handler: &mut SyscallHintProcessor,
+    syscall_handler: &mut SyscallHandlerBase,
     cheatnet_state: &mut CheatnetState,
     mut entry_point: CallEntryPoint,
     starknet_identifier: &AddressOrClassHash,
 ) -> CallResult {
     let exec_result = execute_call_entry_point(
         &mut entry_point,
-        syscall_handler.base.state,
+        syscall_handler.state,
         cheatnet_state,
-        syscall_handler.base.context,
+        syscall_handler.context,
         false,
     );
 
     let result = CallResult::from_execution_result(&exec_result, starknet_identifier);
 
     if let Ok(call_info) = exec_result {
-        syscall_handler.base.inner_calls.push(call_info);
+        syscall_handler.inner_calls.push(call_info);
     }
 
     result

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/declare.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/declare.rs
@@ -5,7 +5,12 @@ use crate::runtime_extensions::forge_runtime_extension::{
 };
 use anyhow::{Context, Result};
 use blockifier::execution::contract_class::{CompiledClassV1, RunnableCompiledClass};
+use blockifier::execution::native::contract_class::NativeCompiledClassV1;
 use blockifier::state::{errors::StateError, state_api::State};
+use cairo_lang_starknet_classes::contract_class::{
+    ContractClass, version_id_from_serialized_sierra_program,
+};
+use cairo_native::executor::AotContractExecutor;
 use conversions::IntoConv;
 use conversions::serde::serialize::CairoSerialize;
 use starknet::core::types::contract::SierraClass;
@@ -32,7 +37,33 @@ pub fn declare(
         get_current_sierra_version(),
     )
     .expect("Failed to read contract class from json");
-    let contract_class = RunnableCompiledClass::V1(contract_class);
+
+    // TODO: We are compiling a contract class with Native each time its
+    // declared. We should compile it once, like we do with CASM.
+
+    let sierra_contract_class: ContractClass =
+        serde_json::from_str(&contract_artifact.sierra).map_err(EnhancedHintError::from)?;
+
+    let (sierra_version, _) =
+        version_id_from_serialized_sierra_program(&sierra_contract_class.sierra_program)
+            .map_err(anyhow::Error::from)
+            .map_err(EnhancedHintError::from)?;
+
+    let aot_executor = AotContractExecutor::new(
+        &sierra_contract_class
+            .extract_sierra_program()
+            .map_err(anyhow::Error::from)
+            .map_err(EnhancedHintError::from)?,
+        &sierra_contract_class.entry_points_by_type,
+        sierra_version,
+        cairo_native::OptLevel::Default,
+        None,
+    )
+    .map_err(anyhow::Error::from)
+    .map_err(EnhancedHintError::from)?;
+
+    let contract_class =
+        RunnableCompiledClass::V1Native(NativeCompiledClassV1::new(aot_executor, contract_class));
 
     let class_hash = *contracts_data
         .get_class_hash(contract_name)

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/deploy.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/cheatcodes/deploy.rs
@@ -3,7 +3,7 @@ use crate::runtime_extensions::call_to_blockifier_runtime_extension::rpc::{
 };
 use anyhow::Result;
 use blockifier::execution::entry_point::ConstructorContext;
-use blockifier::execution::syscalls::hint_processor::SyscallHintProcessor;
+use blockifier::execution::syscalls::syscall_base::SyscallHandlerBase;
 use runtime::EnhancedHintError;
 use std::sync::Arc;
 
@@ -20,14 +20,13 @@ use conversions::string::TryFromHexStr;
 use runtime::starknet::constants::TEST_ADDRESS;
 
 pub fn deploy_at(
-    syscall_handler: &mut SyscallHintProcessor,
+    syscall_handler_base: &mut SyscallHandlerBase,
     cheatnet_state: &mut CheatnetState,
     class_hash: &ClassHash,
     calldata: &[Felt],
     contract_address: ContractAddress,
 ) -> Result<(ContractAddress, Vec<Felt>), CheatcodeError> {
-    if let Ok(class_hash) = syscall_handler
-        .base
+    if let Ok(class_hash) = syscall_handler_base
         .state
         .get_class_hash_at(contract_address)
         && class_hash != ClassHash::default()
@@ -47,9 +46,9 @@ pub fn deploy_at(
     let calldata = Calldata(Arc::new(calldata.to_vec()));
 
     let exec_result = cheated_syscalls::execute_deployment(
-        syscall_handler.base.state,
+        syscall_handler_base.state,
         cheatnet_state,
-        syscall_handler.base.context,
+        syscall_handler_base.context,
         &ctor_context,
         calldata,
         i64::MAX as u64,
@@ -59,7 +58,7 @@ pub fn deploy_at(
     match exec_result {
         Ok(call_info) => {
             let retdata = call_info.execution.retdata.0.clone();
-            syscall_handler.base.inner_calls.push(call_info);
+            syscall_handler_base.inner_calls.push(call_info);
             Ok((contract_address, retdata))
         }
         Err(err) => {
@@ -73,7 +72,7 @@ pub fn deploy_at(
 }
 
 pub fn deploy(
-    syscall_handler: &mut SyscallHintProcessor,
+    syscall_handler_base: &mut SyscallHandlerBase,
     cheatnet_state: &mut CheatnetState,
     class_hash: &ClassHash,
     calldata: &[Felt],
@@ -81,7 +80,7 @@ pub fn deploy(
     let contract_address = cheatnet_state.precalculate_address(class_hash, calldata);
 
     deploy_at(
-        syscall_handler,
+        syscall_handler_base,
         cheatnet_state,
         class_hash,
         calldata,

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -575,14 +575,27 @@ impl<'a> ForgeExtension<'a> {
     fn try_handle_cheatcode(
         &mut self,
         selector: Felt,
-        _input: &[Felt],
-        _runtime: &mut <Self as NativeExtensionLogic>::Runtime,
+        input: &[Felt],
+        runtime: &mut <Self as NativeExtensionLogic>::Runtime,
     ) -> anyhow::Result<NativeSyscallHandlingResult<Vec<Felt>>> {
         let selector_bytes = selector.to_bytes_be();
         let selector = std::str::from_utf8(&selector_bytes)?.trim_start_matches('\0');
 
         let result = match selector {
             "is_config_mode" => false.serialize_to_vec(),
+            "declare" => {
+                let contract_name = BufferReader::new(input).read::<ByteArray>()?.to_string();
+
+                let state = &mut runtime.runtime.runtime.syscall_handler.base.state;
+
+                return handle_declare_deploy_result(declare(
+                    *state,
+                    &contract_name,
+                    self.contracts_data,
+                ))
+                .map(Into::into)
+                .map_err(Into::into);
+            }
             _ => return Ok(NativeSyscallHandlingResult::Forwarded),
         };
 

--- a/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
+++ b/crates/cheatnet/src/runtime_extensions/forge_runtime_extension/mod.rs
@@ -206,7 +206,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     .increment_linear_factor_by(&SyscallSelector::Deploy, calldata.len());
 
                 handle_declare_deploy_result(deploy(
-                    syscall_handler,
+                    &mut syscall_handler.base,
                     cheatnet_runtime.extension.cheatnet_state,
                     &class_hash,
                     &calldata,
@@ -224,7 +224,7 @@ impl<'a> ExtensionLogic for ForgeExtension<'a> {
                     .increment_linear_factor_by(&SyscallSelector::Deploy, calldata.len());
 
                 handle_declare_deploy_result(deploy_at(
-                    syscall_handler,
+                    &mut syscall_handler.base,
                     cheatnet_runtime.extension.cheatnet_state,
                     &class_hash,
                     &calldata,
@@ -592,6 +592,23 @@ impl<'a> ForgeExtension<'a> {
                     *state,
                     &contract_name,
                     self.contracts_data,
+                ))
+                .map(Into::into)
+                .map_err(Into::into);
+            }
+            "deploy" => {
+                let mut input_reader = BufferReader::new(input);
+                let class_hash = input_reader.read()?;
+                let calldata: Vec<_> = input_reader.read()?;
+
+                let cheatnet_runtime = &mut runtime.runtime;
+                let syscall_handler = &mut cheatnet_runtime.runtime.syscall_handler;
+
+                return handle_declare_deploy_result(deploy(
+                    &mut syscall_handler.base,
+                    cheatnet_runtime.extension.cheatnet_state,
+                    &class_hash,
+                    &calldata,
                 ))
                 .map(Into::into)
                 .map_err(Into::into);

--- a/crates/cheatnet/tests/common/mod.rs
+++ b/crates/cheatnet/tests/common/mod.rs
@@ -117,7 +117,7 @@ pub fn deploy_contract(
     );
 
     let (contract_address, _retdata) = deploy(
-        &mut syscall_hint_processor,
+        &mut syscall_hint_processor.base,
         cheatnet_state,
         &class_hash,
         calldata,
@@ -148,7 +148,7 @@ pub fn deploy_wrapper(
     );
 
     let (contract_address, _retdata) = deploy(
-        &mut syscall_hint_processor,
+        &mut syscall_hint_processor.base,
         cheatnet_state,
         class_hash,
         calldata,
@@ -179,7 +179,7 @@ pub fn deploy_at_wrapper(
     );
 
     let (contract_address, _retdata) = deploy_at(
-        &mut syscall_hint_processor,
+        &mut syscall_hint_processor.base,
         cheatnet_state,
         class_hash,
         calldata,
@@ -227,7 +227,7 @@ pub fn call_contract(
     );
 
     call_entry_point(
-        &mut syscall_hint_processor,
+        &mut syscall_hint_processor.base,
         cheatnet_state,
         entry_point,
         &AddressOrClassHash::ContractAddress(*contract_address),

--- a/crates/runtime/src/native.rs
+++ b/crates/runtime/src/native.rs
@@ -7,6 +7,8 @@ use cairo_native::starknet::{
 use cairo_vm::Felt252;
 use conversions::serde::serialize::SerializeToFeltVec;
 
+use crate::CheatcodeHandlingResult;
+
 pub struct NativeExtendedRuntime<E: NativeExtensionLogic> {
     pub extension: E,
     pub runtime: E::Runtime,
@@ -15,6 +17,15 @@ pub struct NativeExtendedRuntime<E: NativeExtensionLogic> {
 pub enum NativeSyscallHandlingResult<T> {
     Forwarded,
     Handled(T),
+}
+
+impl From<CheatcodeHandlingResult> for NativeSyscallHandlingResult<Vec<Felt252>> {
+    fn from(value: CheatcodeHandlingResult) -> Self {
+        match value {
+            CheatcodeHandlingResult::Forwarded => Self::Forwarded,
+            CheatcodeHandlingResult::Handled(felts) => Self::Handled(felts),
+        }
+    }
 }
 
 pub trait NativeExtensionLogic {


### PR DESCRIPTION
Implements the following syscalls for running simple contract tests:

- `declare` cheatcode, in `ForgeExtension `.
- `deploy` cheatcode, in `ForgeExtension `.
- `call_contract` syscall, in `CallToBlockifierExtension`.