### PR TITLE
Add CLI argument to run tests with Native

### DIFF
--- a/crates/forge-runner/src/forge_config.rs
+++ b/crates/forge-runner/src/forge_config.rs
@@ -27,6 +27,7 @@ pub struct TestRunnerConfig {
     pub environment_variables: HashMap<String, String>,
     pub tracked_resource: ForgeTrackedResource,
     pub experimental_oracles: bool,
+    pub use_native: bool,
 }
 
 #[derive(Debug, PartialEq)]

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -81,18 +81,21 @@ pub fn run_test(
             return TestCaseSummary::Interrupted {};
         }
 
-        let run_result = run_native_test_case(
-            &case,
-            &_aot_executor,
-            &RuntimeConfig::from(&forge_config.test_runner_config),
-            None,
-        );
-        // let run_result = run_test_case(
-        //     &case,
-        //     &_casm_program,
-        //     &RuntimeConfig::from(&forge_config.test_runner_config),
-        //     None,
-        // );
+        let run_result = if forge_config.test_runner_config.use_native {
+            run_native_test_case(
+                &case,
+                &_aot_executor,
+                &RuntimeConfig::from(&forge_config.test_runner_config),
+                None,
+            )
+        } else {
+            run_test_case(
+                &case,
+                &_casm_program,
+                &RuntimeConfig::from(&forge_config.test_runner_config),
+                None,
+            )
+        };
 
         if send.is_closed() {
             return TestCaseSummary::Interrupted {};

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -66,8 +66,8 @@ pub use syscall_handler::syscall_handler_offset;
 #[must_use]
 pub fn run_test(
     case: Arc<TestCaseWithResolvedConfig>,
-    _casm_program: Arc<AssembledProgramWithDebugInfo>,
-    _aot_executor: Arc<AotNativeExecutor>,
+    casm_program: Arc<AssembledProgramWithDebugInfo>,
+    aot_executor: Arc<AotNativeExecutor>,
     forge_config: Arc<ForgeConfig>,
     versioned_program_path: Arc<Utf8PathBuf>,
     send: Sender<()>,
@@ -84,14 +84,14 @@ pub fn run_test(
         let run_result = if forge_config.test_runner_config.use_native {
             run_native_test_case(
                 &case,
-                &_aot_executor,
+                &aot_executor,
                 &RuntimeConfig::from(&forge_config.test_runner_config),
                 None,
             )
         } else {
             run_test_case(
                 &case,
-                &_casm_program,
+                &casm_program,
                 &RuntimeConfig::from(&forge_config.test_runner_config),
                 None,
             )

--- a/crates/forge-runner/src/running.rs
+++ b/crates/forge-runner/src/running.rs
@@ -459,7 +459,7 @@ pub fn run_native_test_case(
         extension: ForgeExtension {
             environment_variables: runtime_config.environment_variables,
             contracts_data: runtime_config.contracts_data,
-            fuzzer_rng,
+            fuzzer_rng: fuzzer_rng.cloned(),
             experimental_oracles_enabled: runtime_config.experimental_oracles,
             oracle_hint_service: OracleHintService::default(),
         },

--- a/crates/forge/src/combine_configs.rs
+++ b/crates/forge/src/combine_configs.rs
@@ -29,6 +29,7 @@ pub fn combine_configs(
     additional_args: &[OsString],
     trace_args: TraceArgs,
     experimental_oracles: bool,
+    use_native: bool,
 ) -> ForgeConfig {
     let execution_data_to_save = ExecutionDataToSave::from_flags(
         save_trace_data || forge_config_from_scarb.save_trace_data,
@@ -53,6 +54,7 @@ pub fn combine_configs(
             tracked_resource,
             environment_variables: env::vars().collect(),
             experimental_oracles,
+            use_native,
         }),
         output_config: Arc::new(OutputConfig {
             trace_args,
@@ -84,6 +86,7 @@ mod tests {
             &[],
             TraceArgs::default(),
             false,
+            false,
         );
         let config2 = combine_configs(
             false,
@@ -100,6 +103,7 @@ mod tests {
             &ForgeConfigFromScarb::default(),
             &[],
             TraceArgs::default(),
+            false,
             false,
         );
 
@@ -129,6 +133,7 @@ mod tests {
             &[],
             TraceArgs::default(),
             false,
+            false,
         );
         assert_eq!(
             config,
@@ -144,6 +149,7 @@ mod tests {
                     contracts_data: ContractsData::default(),
                     environment_variables: config.test_runner_config.environment_variables.clone(),
                     experimental_oracles: false,
+                    use_native: false
                 }),
                 output_config: Arc::new(OutputConfig {
                     detailed_resources: false,
@@ -185,6 +191,7 @@ mod tests {
             &[],
             TraceArgs::default(),
             false,
+            false,
         );
         assert_eq!(
             config,
@@ -200,6 +207,7 @@ mod tests {
                     contracts_data: ContractsData::default(),
                     environment_variables: config.test_runner_config.environment_variables.clone(),
                     experimental_oracles: false,
+                    use_native: false
                 }),
                 output_config: Arc::new(OutputConfig {
                     detailed_resources: true,
@@ -245,6 +253,7 @@ mod tests {
             &[],
             TraceArgs::default(),
             false,
+            false,
         );
 
         assert_eq!(
@@ -261,6 +270,7 @@ mod tests {
                     contracts_data: ContractsData::default(),
                     environment_variables: config.test_runner_config.environment_variables.clone(),
                     experimental_oracles: false,
+                    use_native: false
                 }),
                 output_config: Arc::new(OutputConfig {
                     detailed_resources: true,

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -277,6 +277,7 @@ pub enum ExitStatus {
 
 pub fn main_execution(ui: Arc<UI>) -> Result<ExitStatus> {
     let cli = Cli::parse();
+
     match cli.subcommand {
         ForgeSubcommand::Init { name } => {
             init::init(name.as_str(), &ui)?;

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -220,6 +220,9 @@ pub struct TestArgs {
     #[arg(long, default_value_t = false, env = "SNFORGE_EXPERIMENTAL_ORACLES")]
     experimental_oracles: bool,
 
+    #[arg(long, default_value_t = false)]
+    use_native: bool,
+
     #[command(flatten)]
     scarb_args: ScarbArgs,
 }
@@ -274,7 +277,6 @@ pub enum ExitStatus {
 
 pub fn main_execution(ui: Arc<UI>) -> Result<ExitStatus> {
     let cli = Cli::parse();
-
     match cli.subcommand {
         ForgeSubcommand::Init { name } => {
             init::init(name.as_str(), &ui)?;

--- a/crates/forge/src/lib.rs
+++ b/crates/forge/src/lib.rs
@@ -220,6 +220,7 @@ pub struct TestArgs {
     #[arg(long, default_value_t = false, env = "SNFORGE_EXPERIMENTAL_ORACLES")]
     experimental_oracles: bool,
 
+    /// Run tests with Native.
     #[arg(long, default_value_t = false)]
     use_native: bool,
 

--- a/crates/forge/src/run_tests/package.rs
+++ b/crates/forge/src/run_tests/package.rs
@@ -108,6 +108,7 @@ impl RunForPackageArgs {
             &args.additional_args,
             args.trace_args.clone(),
             args.experimental_oracles,
+            args.use_native,
         ));
 
         let test_filter = TestsFilter::from_flags(

--- a/crates/forge/test_utils/src/running_tests.rs
+++ b/crates/forge/test_utils/src/running_tests.rs
@@ -79,6 +79,7 @@ pub fn run_test_case(
                     tracked_resource,
                     environment_variables: test.env().clone(),
                     experimental_oracles: false,
+                    use_native: false,
                 }),
                 output_config: Arc::new(OutputConfig {
                     detailed_resources: false,

--- a/crates/forge/tests/integration/setup_fork.rs
+++ b/crates/forge/tests/integration/setup_fork.rs
@@ -161,6 +161,7 @@ fn fork_aliased_decorator() {
                         tracked_resource: ForgeTrackedResource::CairoSteps,
                         environment_variables: test.env().clone(),
                         experimental_oracles: false,
+                        use_native: false,
                     }),
                     output_config: Arc::new(OutputConfig {
                         detailed_resources: false,
@@ -254,6 +255,7 @@ fn fork_aliased_decorator_overrding() {
                         tracked_resource: ForgeTrackedResource::CairoSteps,
                         environment_variables: test.env().clone(),
                         experimental_oracles: false,
+                        use_native: false,
                     }),
                     output_config: Arc::new(OutputConfig {
                         detailed_resources: false,

--- a/docs/src/appendix/snforge/test.md
+++ b/docs/src/appendix/snforge/test.md
@@ -80,6 +80,10 @@ Control when colored output is used. Valid values:
 - `always`: always display colors.
 - `never`: never display colors.
 
+## `--use-native`
+
+When used, it makes snforge to use Cairo Native instead of the VM to run the tests. 
+
 ## `--detailed-resources`
 
 Display additional info about used resources for passed tests.


### PR DESCRIPTION
To use it run:
```shell
snforge test --use-native
```

## Introduced changes

<!-- A brief description of the changes -->

- Add new CLI argument to run tests with Native

## Checklist

<!-- Make sure all of these are complete -->

- [ ] Linked relevant issue
- [ ] Updated relevant documentation
- [ ] Added relevant tests
- [ ] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
